### PR TITLE
existing rprofile bug fix

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: cabinets
 Title: Project Specific Workspace Organization Templates
-Version: 0.3.1.9000
+Version: 0.3.2.9000
 Authors@R: 
     person(given = "Nick",
            family = "Williams",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# cabinets 0.3.2.9000
+
+* bug fix for cabinets permission when .Rprofile already exists on first use.
+
 # cabinets 0.3.1
 
 * `edit_r_profile()` can now be called to automatically open the .Rprofile file for editing

--- a/R/checks.R
+++ b/R/checks.R
@@ -71,7 +71,7 @@ check_permissions <- function() {
 check_r_profile <- function() {
     file_stat <- !file.exists(file.path(normalizePath("~"), ".Rprofile"))
 
-    perm_yes <- function() {
+    new_rprof <- function() {
         message("Creating .Rprofile...")
         r_profile <- file.path(normalizePath("~"), ".Rprofile")
         file.create(r_profile)
@@ -84,12 +84,31 @@ check_r_profile <- function() {
         writeLines(permission, r_profile)
     }
 
+    old_rprof <- function() {
+        r_profile_path <- file.path(normalizePath("~"), ".Rprofile")
+        rprof_lines <- readLines(r_profile_path)
+        perm_status <- any(grepl("cabinets_options_set", rprof_lines))
+
+        permission <- glue::glue(
+            "# cabinets permission
+            cabinets::cabinets_options_set('cabinets.permission' = TRUE)"
+        )
+
+        if (perm_status) {
+            on.exit()
+        } else {
+            r_profile <- file(r_profile_path, open = "a")
+            writeLines(permission, r_profile)
+            close(r_profile)
+        }
+    }
+
     message("Checking for .Rprofile...")
     status <- tryCatch(if (file_stat) {
         message(".Rprofile not found.")
-        perm_yes()
+        new_rprof()
     } else {
-        on.exit()
+        old_rprof()
     })
     invisible(status)
 }


### PR DESCRIPTION
Addresses issue #18 

Adds function inside of `check_r_profile()` that in the case of an existing .Rprofile uses regex to search if cabinets permission already exists and if it doesn't writes the permission. 

DESCRIPTION and NAMESPACE updated to reflect fix. 

This PR doesn't introduce any failed CMD checks. 